### PR TITLE
version in the case of HEAD

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
@@ -5,8 +5,24 @@ package Dist::Zilla::Plugin::ChangelogFromGit::CPAN::Changes;
 use Moose;
 use CPAN::Changes;
 use CPAN::Changes::Release;
+use Moose::Util::TypeConstraints;
+use String::Formatter 0.100680 stringf => {
+  -as => '_head_format',
+
+  input_processor => 'require_single_input',
+  string_replacer => 'method_replace',
+  codes => {
+    v => sub { $_[0] }
+  },
+};
 
 extends 'Dist::Zilla::Plugin::ChangelogFromGit';
+
+has head_format => (
+  is  => 'ro',
+  isa => 'Str',
+  default => 'v%v',
+);
 
 sub render_changelog {
     my ($self) = @_;
@@ -18,7 +34,7 @@ sub render_changelog {
 
         my $version = $release->version;
         if ( $version eq 'HEAD' ) {
-            $version = $self->zilla->version;
+            $version = _head_format($self->head_format, $self->zilla->version);
         }
 
         my $cpan_release = CPAN::Changes::Release->new(
@@ -51,6 +67,19 @@ sub render_changelog {
 __PACKAGE__->meta->make_immutable;
 
 1;
+
+__END__
+
+=for Pod::Coverage
+    provide_version
+
+=head1 SYNOPSIS
+
+In your F<dist.ini>:
+
+    [ChangelogFromGit::CPAN::Changes]
+    ; All options of [ChangelogFromGit], plus eventually:
+    head_format = %v            ; this is the default
 
 =head1 SEE ALSO
 


### PR DESCRIPTION
Hello,

When the plugin reaches the HEAD, it outputs zilla->version, and $release->version in all other cases. But $release->version are in reality tags, and /if/ the dzil release is going to do a Git::Tag, it will then obey to the config:

``` ini
[Git::Tag]          ; tag repo with custom tag
tag_format = v%v
```

Let's go to the problem. For example, suppose we go from version 0.13 to 0.14, tagged v0.13 and v0.14:

Your plugin will generate this Changes file:

```
0.13
 - something
v0.12
 - before
```

which is commited under tag v0.13. The next iteration will produce:

```
0.14
 - something else
v0.13
 - something
v0.12
 - before
```

so the diff on the commit will be:

``` diff
1,3c1
< 0.14
<  - something else
< v0.13

---
> 0.13
```

You see the problem.

IMHO the best solution would be to inherit from Git::Tag and recuperate its tag_format. In case you want a standalone solution, this could to be coded in your module. I did that in a lazy way, because it fits MY setup: coding inside the module, with /only/ the %v format string modifier. While Git::Tag allows more.

So please do not consider pulling this request as is, but, instead, please consider this pull request as a former proof of concept of the problem.
What is the best solution, /if/ you dare to tackle this problem, I do not know....

Thanks,

Regards, Jean-Damien.
