### PR TITLE
downgrade requirements to Perl 5.10.1

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
@@ -2,7 +2,7 @@ package Dist::Zilla::Plugin::ChangelogFromGit::CPAN::Changes;
 
 # ABSTRACT: Generate valid CPAN::Changes Changelogs from git
 
-use v5.10.2;
+use v5.10.1;
 use Moose;
 use Moose::Util::TypeConstraints;
 use Class::Load 'try_load_class';


### PR DESCRIPTION
travis-ci does not support Perl 5.10.2 but 5.10.1 only, so all build tests on 5.10 fail when using this module.  By the way I cannot find Perl 5.10.2 in the [release history](http://perldoc.perl.org/index-history.html).
