### PR TITLE
Fix invalid array access when one version entry in Changes

### DIFF
--- a/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
+++ b/lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm
@@ -183,7 +183,7 @@ sub _build__last_release {
     my $self = shift;
 
     my @releases = $self->_changes->releases;
-    if (scalar @releases > 0) {
+    if (scalar @releases > 1) {
         my $last_release = version->parse($releases[-1]->version);
         $self->logger->log("Last release in changelog: $last_release");
 


### PR DESCRIPTION
_build__last_release() will fail if there's only one entry in Changes
file, and the entry has same version number as the current build,
i.e. when invoking consecutive executions of dzil without releasing.
This will choose the code path inside the if block.

```
if (scalar @releases > 0) {
```

But then later this will cause a method invocation on an undefined value

```
        $last_release = $releases[-2]->version;
```

Since there's only one entry in the $releases arrayref, the negative
array index will return undef and the method invocation fails

Can't call method "version" on an undefined value at ...
