### PR TITLE
explicitly define prereqs

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,6 +14,9 @@ disable = Test::NoTabs
 encoding = bytes
 match = \.gz$
 
+[Prereqs]
+Path::Class = 0.35
+
 [Prereqs / RuntimeRecommends]
 Proc::InvokeEditor = 0
 


### PR DESCRIPTION
Path::Class must be at least 0.35 for copy_to(), which causes the
following error:

    Can't locate object method "copy_to" via package "Path::Class::File"
    at lib/Dist/Zilla/Plugin/ChangelogFromGit/CPAN/Changes.pm line 180.

It's also a good idea to explicitly list the modules depended on, in case other expected modules change their prereqs.